### PR TITLE
Add Dreame 1C support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Valetudo](https://github.com/Hypfer/Valetudo) voice pack to let your vacuum robot speak and scream like Zoidberg.
 
-Works at least with `L10 Pro`, `Z10 Pro`, `W10`, and `D9`.
+Works at least with `L10 Pro`, `Z10 Pro`, `W10`, and `D9`, `Dreame 1C`.
 
 ## Installation
 


### PR DESCRIPTION
I tested it with my Dreame 1C ([dreame.vacuum.mc1808(https://robotinfo.dev/detail_dreame.vacuum.mc1808_0.html) and it works.